### PR TITLE
[FIX] Change hidden files name separator

### DIFF
--- a/file-hider.py
+++ b/file-hider.py
@@ -3,6 +3,7 @@ import os
 
 CUSTOM_EOF = b'\x1f\x66\x69\x6c\x65\x2d\x68\x69\x64\x65\x72\x1f'
 FILE_NAME_SEPARATOR = b'\x1c\x73\x70\x6C\x69\x74\x1c'
+PREFIX_RECOVERED_FILE = 'recovered_'
 
 
 def printHeader():
@@ -77,12 +78,13 @@ def recover_files(camouflaged_file_name, destination_folder):
     print()
 
     print('Recovering original camouflaged file ...')
-    with open('recover_' + get_file_name(camouflaged_file_name), 'wb') as recover_camouflaged_file:
+    with open(PREFIX_RECOVERED_FILE + get_file_name(camouflaged_file_name), 'wb') as recover_camouflaged_file:
         recover_camouflaged_file.write(camouflaged_data[0])
 
     for i in range(len(camouflaged_data) - 1):
         secret_file = camouflaged_data[i + 1].split(FILE_NAME_SEPARATOR)
-        secret_file_name = secret_file[0].decode('utf-8')
+        secret_file_name = PREFIX_RECOVERED_FILE + \
+            secret_file[0].decode('utf-8')
         secret_file_data = secret_file[1]
 
         print('Recovering file ' + secret_file_name + '...')

--- a/file-hider.py
+++ b/file-hider.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 CUSTOM_EOF = b'\x1f\x66\x69\x6c\x65\x2d\x68\x69\x64\x65\x72\x1f'
-FILE_NAME_SEPARATOR = b'\x1c'
+FILE_NAME_SEPARATOR = b'\x1c\x73\x70\x6C\x69\x74\x1c'
 
 
 def printHeader():


### PR DESCRIPTION
# Description
There are some files that contains the `FILE_NAME_SEPARATOR`character as a content and when the script is recovering the file and found the special character split the content in a wrong way and create a corrupt file.

# Solution
Use another pattern to split the name and content in hidden files

# Extra
- Added a prefix `recovered_` in recovered files
 
# Test Evidence
## Before
<img width="645" alt="Screenshot 2023-04-20 at 13 46 12" src="https://user-images.githubusercontent.com/12779378/233446718-0cd045a4-2124-4840-8341-ae7bdb7a7580.png">

## After
<img width="659" alt="Screenshot 2023-04-20 at 13 45 00" src="https://user-images.githubusercontent.com/12779378/233446992-bdfcfbd9-784b-43ac-8523-8e758361a017.png">

